### PR TITLE
Fix problematic quoting when launching Forscan with Wine

### DIFF
--- a/Casks/forscan.rb
+++ b/Casks/forscan.rb
@@ -59,7 +59,7 @@ cask "forscan" do
     end try
 
     -- Finally open the FORScan application itself through Wine
-    do shell script "/opt/homebrew/bin/wine $HOME'/.wine/drive_c/Program Files (x86)/FORScan/FORScan.exe'"
+    do shell script "open -a 'Wine Stable' '~/.wine/drive_c/Program Files (x86)/FORScan/FORScan.exe'"
   EOS
 
   # Source: https://www.artembutusov.com/how-to-wrap-wine-applications-into-macos-x-application-bundle/

--- a/Casks/forscan.rb
+++ b/Casks/forscan.rb
@@ -59,7 +59,7 @@ cask "forscan" do
     end try
 
     -- Finally open the FORScan application itself through Wine
-    do shell script "open -a 'Wine Stable' \\"$HOME/.wine/drive_c/Program Files (x86)/FORScan/FORScan.exe\\""
+    do shell script "/opt/homebrew/bin/wine $HOME'/.wine/drive_c/Program Files (x86)/FORScan/FORScan.exe'"
   EOS
 
   # Source: https://www.artembutusov.com/how-to-wrap-wine-applications-into-macos-x-application-bundle/


### PR DESCRIPTION
After installing the app as per the readme, I ran it from the applications folder but it just opens a terminal with the wine prompt. MacOS 15.3 on a M4 MBP. 

A bit of debugging I found that the command to open it didn’t seem to be passing the path to wine. It also seemed to be breaking at the space in the path “Program Files”. Using single quotes would keep the path together but then the $HOME variable wouldn’t work inside the quotes. The only way I could get it working was call the wine binary directly and move the home variable out of the single quotes. 

I don’t have much experience with this language it was a bit of trial and error to find what worked so it may be a little hacky or could be improved. 

I’ve only had my MacBook a month so I don’t know if it’s a recent change Apple made. For me the app hasn’t opened since I first tried it.