### PR TITLE
Major code cleanup, hide unneccessary logs and use zap instead of uninstall

### DIFF
--- a/Casks/forscan.rb
+++ b/Casks/forscan.rb
@@ -1,9 +1,15 @@
+# This installs a Windows Program FORScan into MacOS
+# It uses Wine and creates a MacOS app bundle for it in pretty unorthodox way
 cask "forscan" do
   version "2.3.65"
   sha256 "d16c86878e7e758db92dc4b695d7e3b25cd36d04ecfd8ed62c8135dae5bd524c"
 
   url "https://forscan.org/download/FORScanSetup#{version}.release.exe"
-  name "FORScan"
+  
+  # Also store the names into variables for easier reuse later
+  name (name = "FORScan")
+  app (app = "#{name}.app")
+
   desc "Software scanner for Ford, Mazda, Lincoln and Mercury vehicles"
   homepage "https://forscan.org/home.html"
 
@@ -12,18 +18,66 @@ cask "forscan" do
     regex(%r{href=.*download/FORScanSetup(\d+(?:\.\d+)+)\.release\.exe})
   end
 
+  # This is a Windows program on MacOS so it doesn't update itself
   auto_updates false
-  depends_on macos: ">= :big_sur"
+
+  # Use same Depends on as wine-stable
+  # https://github.com/Homebrew/homebrew-cask/blob/master/Casks/w/wine-stable.rb#L39
+  depends_on macos: ">= :catalina"
+
   # Since Forscan is made for Windows we need to install Wine to run it
   depends_on cask: "wine-stable"
+
   # Virtual COM Drivers which work for vLinker FS USB OBD2 reader
   # They also should work for the OBDLink EX which is the other recommended cable
   # These are needed for the MacOS host machine to detect the OBD2 reader
   depends_on cask: "ftdi-vcp-driver"
 
-  app "FORScan.app"
-  # Remember to escape the backslash properly inside this script \
-  forscan_launcher_content = <<~EOS
+  # Intel Macs have homebrew in:   /usr/local/bin/brew
+  # Apple Silicon Macs have it in: /opt/homebrew/bin/brew
+  # This uses correct Wine path for both systems
+  wine_executable = "#{HOMEBREW_PREFIX}/bin/wine"
+
+  # Check if the homebrew install/uninstall wants to see the Wine output
+  is_verbose_mode = (ARGV & %w[-v --verbose --debug -d]).any?
+
+  # Runs the Forscan Windows installer
+  installer script: {
+    executable: wine_executable,
+    # Wine output is confusing and not helpful for most of us
+    print_stderr: is_verbose_mode,
+    args: [
+      # You can find the exe installer flags by running:
+      # $ wine FORScanSetup2.3.65.release.exe /help
+      # Default installation path is C:/Program Files (x86)/FORScan/
+      "#{staged_path}/FORScanSetup#{version}.release.exe",
+      # Windows .exe installer flags here:
+      "/SP-", # No questions for user
+      *("/VERYSILENT" unless is_verbose_mode) # No output
+    ]
+  }
+
+  # This currently opens interactive dialog which asks if user wants to remove or not
+  zap script: {
+    executable: wine_executable,
+    print_stderr: is_verbose_mode,
+    args: [
+      # Homebrew escapes special characters here so ~ or $HOME won't work
+      "#{Dir.home}/.wine/drive_c/Program\ Files\ \(x86\)/FORScan/unins000.exe",
+      # FIXME: The unins000.exe doesn't have flags which would allow silent uninstall
+    ]
+  }
+
+  zap trash: [
+    "~/.wine/drive_c/Program Files (x86)/FORScan",
+    "~/.wine/drive_c/ProgramData/Microsoft/Windows/Start Menu/Programs/FORScan",
+    # Remove the com ports created by the launcher
+    "~/.wine/dosdevices/com*",
+  ]
+
+  # Contents for the executable script inside the .app folder
+  # Remember to escape the backslash '\' properly inside this script
+  launcher_content = <<~EOS
     #!/usr/bin/osascript
 
     -- Ensure that the USB drivers have been installed already
@@ -52,30 +106,30 @@ cask "forscan" do
         -- Symlink the found serial devices to Wine
         do shell script "ln -sf " & serialDevicePath & " ~/.wine/dosdevices/" & comPort
         -- Add Windows registries for the symlinked com ports
-        do shell script "#{HOMEBREW_PREFIX}/bin/wine reg add 'HKLM\\\\Software\\\\Wine\\\\Ports' /f /v " & comPort & " /t REG_SZ /d " & serialDevicePath
+        do shell script "#{wine_executable} reg add 'HKLM\\\\Software\\\\Wine\\\\Ports' /f /v " & comPort & " /t REG_SZ /d " & serialDevicePath
       end repeat
     on error
       display dialog "Connect your USB cable to MacOS first and re-open FORScan" with title "ERROR: No USB serial cables were found!" buttons {"Continue anyway", "Cancel"} default button "Cancel" cancel button "Cancel"
     end try
 
     -- Finally open the FORScan application itself through Wine
-    do shell script "#{HOMEBREW_PREFIX}/bin/wine $HOME'/.wine/drive_c/Program Files (x86)/FORScan/FORScan.exe'"
+    do shell script "#{wine_executable} $HOME'/.wine/drive_c/Program Files (x86)/FORScan/FORScan.exe'"
   EOS
 
   # Source: https://www.artembutusov.com/how-to-wrap-wine-applications-into-macos-x-application-bundle/
-  forscan_plist_content = <<~EOS
+  plist_content = <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">
     <dict>
       <key>CFBundleExecutable</key>
-      <string>FORScan</string>
+      <string>#{name}</string>
       <key>CFBundleIconFile</key>
       <string>AppIcon</string>
       <key>CFBundleIconName</key>
       <string>AppIcon</string>
       <key>CFBundleName</key>
-      <string>FORScan</string>
+      <string>#{name}</string>
       <key>CFBundlePackageType</key>
       <string>APPL</string>
       <key>CFBundleShortVersionString</key>
@@ -88,39 +142,34 @@ cask "forscan" do
     </plist>
   EOS
 
-  # Runs the Forscan Windows installer
-  installer script: {
-    executable: "wine",
-    args:       [
-      "#{staged_path}/FORScanSetup#{version}.release.exe",
-      # Windows EXE installer options here:
-      # Run the forscan without user input
-      "/SP-",
-      "/VERYSILENT",
-      # Default installation path is C:/Program Files (x86)/FORScan/
-    ],
-  }
-
-  # Create the Forscan.app using ducktape
+  # Create the Forscan.app using ducktape which homebrew then moves to /Applications
+  # /Applications/Forscan.app
+  # └── Contents
+  #     ├── Info.plist <-- MacOS app bundle metadata from plist_content variable
+  #     ├── MacOS
+  #     │   └── FORScan <-- Executable from launcher_content variable
+  #     └── Resources
+  #         ├── AppIcon.icns <-- Converted with sips from AppIcon.png
+  #         └── AppIcon.png <-- Extracted from Forscan.lnk Windows shortcut
   preflight do
     # Create the app bundle structure
-    FileUtils.mkdir_p "#{staged_path}/FORScan.app/Contents/MacOS"
-    Dir.chdir("#{staged_path}/FORScan.app/Contents") do
+    FileUtils.mkdir_p "#{staged_path}/#{app}/Contents/MacOS"
+    Dir.chdir("#{staged_path}/#{app}/Contents") do
       # Create the executable script
-      File.write "MacOS/FORScan", forscan_launcher_content
-      FileUtils.chmod 0755, "MacOS/FORScan"
+      File.write "MacOS/#{name}", launcher_content
+      FileUtils.chmod 0755, "MacOS/#{name}"
 
       # Create the Info.plist
-      File.write "Info.plist", forscan_plist_content
+      File.write "Info.plist", plist_content
     end
   end
 
-  # The shortcut in drive_c is not available preflight
+  # The FORScan.lnk shortcut in drive_c is not available preflight
   # because the installer.exe has not been used yet
   postflight do
     # Create the FORScan.app icon
-    FileUtils.mkdir "#{staged_path}/FORScan.app/Contents/Resources"
-    Dir.chdir("#{staged_path}/FORScan.app/Contents/Resources") do
+    FileUtils.mkdir "#{staged_path}/#{app}/Contents/Resources"
+    Dir.chdir("#{staged_path}/#{app}/Contents/Resources") do
       # Use Wine utility to extract icon from the Windows shortcut
       win_shortcut = '~/.wine/drive_c/ProgramData/Microsoft/Windows/Start\ Menu/Programs/FORScan/FORScan.lnk'
       `#{HOMEBREW_PREFIX}/bin/wine winemenubuilder -t #{win_shortcut} AppIcon.png`
@@ -128,12 +177,6 @@ cask "forscan" do
       `sips -s format icns AppIcon.png -o AppIcon.icns`
     end
     # Force MacOS to refresh the icon cache
-    FileUtils.touch "#{staged_path}/FORScan.app"
+    FileUtils.touch "#{staged_path}/#{app}"
   end
-
-  # TODO: Maybe this could use the "unins000.exe" inside FORScan instead. The delete key requires password
-  uninstall delete: [
-    "~/.wine/drive_c/Program Files (x86)/FORScan",
-    "~/.wine/drive_c/ProgramData/Microsoft/Windows/Start Menu/Programs/FORScan",
-  ]
 end


### PR DESCRIPTION
This builds on top of #12.

After this the code is explained well and organized well.

Unnecessary output from Wine is hidden from the user (but can still be seen when running `brew install onnimonni/tap/forscan --verbose`).

Earlier way required sudo password everytime when updating the FORScan because the uninstall directive deleted the files. I tested that the uninstall between updates is not needed.

Now if user wants to remove all FORScan related they need to run:
```
brew uninstall forscan --zap
```

This will remove all the files and will also run interactive uninstaller.exe from FORScan installer.exe.

This way it should be easier to understand and nicer to use 👍.

It most likely doesn't matter too much for anyone except me but I hope you're happy.