### PR TITLE
Forscan Serial Cable Not Detected Reg Fix

### DIFF
--- a/FORScan.app/Contents/MacOS/FORScan
+++ b/FORScan.app/Contents/MacOS/FORScan
@@ -38,7 +38,7 @@ on run args
             -- Symlink the found serial devices to Wine
             do shell script "ln -sf " & serialDevicePath & " ~/.wine/dosdevices/" & comPort
             -- Add Windows registries for the symlinked com ports
-            do shell script "/opt/homebrew/bin/wine reg add 'HKLM\\\\Software\\\\Wine\\\\Ports' /f /v " & comPort & " /t REG_SZ /d " & serialDevicePath
+            do shell script "/opt/homebrew/bin/wine reg add 'HKLM\\Software\\Wine\\Ports' /f /v " & comPort & " /t REG_SZ /d " & serialDevicePath
         end repeat
     on error
         display dialog "Connect your USB cable to MacOS first and re-open FORScan" with title "ERROR: No USB serial cables were found!" buttons {"Continue anyway", "Cancel"} default button "Cancel" cancel button "Cancel"


### PR DESCRIPTION
Not sure if this is related to a recent Wine or Mac OS update, but I started getting a message to say no USB Serial cables found. If I click continue anyway Forscan worked fine other than the message not going away until I closed Forscan. 

Bit of debugging and it seems that the extra backslashes for the reg entry were causing wine to return an error. This PR fixed the issue for me.