### PR TITLE
Update README to explain FTDI driver inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ brew install --no-quarantine --cask wine-stable onnimonni/tap/forscan
 > Even though `onnimonni/tap/forscan` requires Wine Stable.
 > Because of this it's easiest to install this by running them both here
 
+#### FTDI Virtual COM Port Driver (Driver for USB to OBD2 Cable)
+
+- The `forscan` cask includes the `ftdi-vcp-driver` cask, and automates installation of the driver, which is required to use USB to OBD2 cables. FORScan recommmends the following cables, which work with this driver:
+    - vLinker FS USB OBD2
+    - OBDLink EX
+
 #### How do I delete FORScan completely?
 
 ```sh


### PR DESCRIPTION
This PR updates the README to clarify that the forscan cask includes the ftdi-vcp-driver cask, automates installation, and provides information about compatible USB to OBD2 cables (vLinker FS USB OBD2 and OBDLink EX).

This helps users who may be aware that they need to install drivers for the cables, and may not know that they are included in the FORScan cask.